### PR TITLE
test script for installation

### DIFF
--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -1,0 +1,23 @@
+name: Test installation from project template
+
+on:
+  push:
+    branches: [2024/test-installation]
+
+jobs:
+  test-installation:
+    # Disables this workflow from running in a repository that is not part of the indicated organization/user
+    if: github.repository_owner == 'cruncher'
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Test installation
+        run: |
+          sh tests/test_installations.sh
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.11"
       - name: Test installation
         run: |
-          sh ${PWD}/tests/test_installations.sh
+          sh ${PWD}/project_name/tests/test_installations.sh
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.11"
       - name: Test installation
         run: |
-          sh ${PWD}/project_name/tests/test_installations.sh
+          sh ${PWD}/tests/test_installations.sh
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -2,7 +2,11 @@ name: Test installation from project template
 
 on:
   push:
-    branches: [2024/test-installation]
+    branches: [ master ]
+
+  pull_request:
+    branches: [ master ]
+  
 
 jobs:
   test-installation:
@@ -31,8 +35,6 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Dependencies
-        run: |
-          sudo apt-get install curl
+        run: sudo apt-get install curl
       - name: Test installation
-        run: |
-          sh ${PWD}/project_name/tests/test_installation.sh
+        run: sh ${PWD}/project_name/tests/test_installation.sh

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -17,9 +17,7 @@ jobs:
           python-version: "3.11"
       - name: Test installation
         run: |
-          pwd
-          find .. -name \*.sh
-          sh ${PWD}/tests/test_installation.sh
+          sh ${PWD}/project_name/tests/test_installation.sh
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -7,9 +7,24 @@ on:
 jobs:
   test-installation:
     # Disables this workflow from running in a repository that is not part of the indicated organization/user
-    if: github.repository_owner == 'cruncher'
+    if: github.repository_name == 'project-template'
 
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_create_from_project_template
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -17,6 +17,8 @@ jobs:
           python-version: "3.11"
       - name: Test installation
         run: |
+          pwd
+          find .. -name \*.sh
           sh ${PWD}/project_name/tests/test_installations.sh
 
         env:

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           pwd
           find .. -name \*.sh
-          sh ${PWD}/project_name/tests/test_installations.sh
+          sh ${PWD}/tests/test_installation.sh
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.11"
       - name: Test installation
         run: |
-          sh tests/test_installations.sh
+          sh ${PWD}/project_name/tests/test_installations.sh
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -30,9 +30,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install curl
       - name: Test installation
         run: |
           sh ${PWD}/project_name/tests/test_installation.sh
-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_installation.yml
+++ b/.github/workflows/test_installation.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-installation:
     # Disables this workflow from running in a repository that is not part of the indicated organization/user
-    if: github.repository_name == 'project-template'
+    # if: github.repository_name == 'project-template'
 
     runs-on: ubuntu-latest
     services:

--- a/project_name/project_name/settings/base.py
+++ b/project_name/project_name/settings/base.py
@@ -44,18 +44,6 @@ DATABASES = {
     }
 }
 
-if os.environ.get("GITHUB_WORKFLOW"):
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.postgresql_psycopg2",
-            "NAME": "test_create_from_project_template",
-            "USER": "postgres",
-            "PASSWORD": "postgres",
-            "HOST": "127.0.0.1",
-            "PORT": "5432",
-        }
-    }
-
 
 ALLOWED_HOSTS = [
     ".cruncher.ch",

--- a/project_name/project_name/settings/base.py
+++ b/project_name/project_name/settings/base.py
@@ -44,6 +44,19 @@ DATABASES = {
     }
 }
 
+if os.environ.get("GITHUB_WORKFLOW"):
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "NAME": "test_create_from_project_template",
+            "USER": "postgres",
+            "PASSWORD": "postgres",
+            "HOST": "127.0.0.1",
+            "PORT": "5432",
+        }
+    }
+
+
 ALLOWED_HOSTS = [
     ".cruncher.ch",
     ".test.cruncher.ch",

--- a/project_name/project_name/settings/local.py-template
+++ b/project_name/project_name/settings/local.py-template
@@ -26,6 +26,7 @@ TEMPLATES = [
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
                 "sekizai.context_processors.sekizai",
+                "cms.context_processors.cms_settings"
             ],
             "debug": True,
             "loaders": [

--- a/project_name/project_name/settings/test.py
+++ b/project_name/project_name/settings/test.py
@@ -1,0 +1,16 @@
+from .base import *  # noqa
+from .cms import *  # noqa
+from .s3 import *  # noqa
+
+
+if os.environ.get("GITHUB_WORKFLOW"):
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "NAME": "test_create_from_project_template",
+            "USER": "postgres",
+            "PASSWORD": "postgres",
+            "HOST": "127.0.0.1",
+            "PORT": "5432",
+        }
+    }

--- a/project_name/project_name/settings/test.py
+++ b/project_name/project_name/settings/test.py
@@ -2,6 +2,10 @@ from .base import *  # noqa
 from .cms import *  # noqa
 from .s3 import *  # noqa
 
+try:
+    from .local import *  # noqa
+except ImportError:
+    print("settings.local not found")
 
 if os.environ.get("GITHUB_WORKFLOW"):
     DATABASES = {

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -14,6 +14,7 @@ PROJECT_DIR=`pwd`
 
 export NEW_PROJECT_NAME=test_create_from_project_template
 export DJANGO_SETTINGS_MODULE=$NEW_PROJECT_NAME.settings.test
+export PGPASSWORD=postgres
 
 pip install django
 
@@ -44,9 +45,9 @@ test_pip() {
 }
 test_db() {
     cd $NEW_PROJECT_NAME
-    if ! createdb $NEW_PROJECT_NAME; then
-    dropdb $NEW_PROJECT_NAME
-    createdb $NEW_PROJECT_NAME
+    if ! createdb -h localhost -p 5432 -U postgres -w $NEW_PROJECT_NAME; then
+    dropdb -h localhost -p 5432 -U postgres -w $NEW_PROJECT_NAME
+    createdb -h localhost -p 5432 -U postgres -w $NEW_PROJECT_NAME
     fi
 }
 
@@ -65,13 +66,4 @@ test_migrate() {
     return
 }
 
-if ! test_installation || ! test_create_virtualenv || ! test_activate_virtualenv || ! test_activate_virtualenv || ! test_pip || ! test_db  || ! test_cp_local || ! test_django_check || ! test_migrate; then
-    dropdb $NEW_PROJECT_NAME
-    cd $BASE_DIR
-    rm -rf .test_tmp/
-    return
-fi
-
-dropdb $NEW_PROJECT_NAME
-cd $BASE_DIR
-rm -rf .test_tmp/
+test_installation && test_create_virtualenv && test_activate_virtualenv && test_activate_virtualenv && test_pip && test_db  && test_cp_local && test_django_check && test_migrate

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -58,7 +58,6 @@ test_cp_local() {
 }
 
 test_django_check() {
-    echo $DJANGO_SETTINGS_MODULE
     python manage.py check --fail-level WARNING --settings=$DJANGO_SETTINGS_MODULE
     return
 }
@@ -67,5 +66,19 @@ test_migrate() {
     python manage.py migrate
     return
 }
+
+test_runserver() {
+    python manage.py runserver 0.0.0.0:8000 &!
+    sleep 3
+    return
+}
+
+
+test_server_runs() {
+    curl -I  http://127.0.0.1:8000/fr/
+    return
+}
+
+
 
 test_installation && test_create_virtualenv && test_activate_virtualenv && test_activate_virtualenv && test_pip && test_db  && test_cp_local && test_django_check && test_migrate

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -13,7 +13,6 @@ cd test_project
 PROJECT_DIR=`pwd`
 
 export NEW_PROJECT_NAME=test_create_from_project_template
-export DJANGO_SETTINGS_MODULE=$NEW_PROJECT_NAME.$NEW_PROJECT_NAME.settings.test
 export PGPASSWORD=postgres
 
 pip install django

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -19,7 +19,7 @@ export PGPASSWORD=postgres
 pip install django
 
 test_installation() {
-    django-admin startproject --template=https://github.com/cruncher/project-template/zipball/master --extension=conf,py,sh,py-template,toml  $NEW_PROJECT_NAME
+    django-admin startproject --template=https://github.com/cruncher/project-template/zipball/2024/test-installation --extension=conf,py,sh,py-template,toml  $NEW_PROJECT_NAME
     cd $NEW_PROJECT_NAME
     sed -i s/{{project_name}}/$NEW_PROJECT_NAME/g $NEW_PROJECT_NAME/templates/base.html
     return

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -81,4 +81,4 @@ test_server_runs() {
 
 
 
-test_installation && test_create_virtualenv && test_activate_virtualenv && test_activate_virtualenv && test_pip && test_db  && test_cp_local && test_django_check && test_migrate
+test_installation && test_create_virtualenv && test_activate_virtualenv && test_activate_virtualenv && test_pip && test_db  && test_cp_local && test_django_check && test_migrate && test_runserver && test_server_runs

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -x  # Print each command before executing it
+
+
+BASE_DIR=`pwd`
+
+mkdir .test_tmp
+cd .test_tmp
+mkdir test_project
+cd test_project
+
+
+test_installation() {
+    export NEW_PROJECT_NAME=test_create_from_project_template
+    ~/.pyenv/versions/3.11.*/bin/django-admin startproject --template=https://github.com/cruncher/project-template/zipball/master --extension=conf,py,sh,py-template,toml  $NEW_PROJECT_NAME
+    cd $NEW_PROJECT_NAME
+    sed -i s/{{project_name}}/$NEW_PROJECT_NAME/g $NEW_PROJECT_NAME/templates/base.html
+    return
+}
+test_create_virtualenv() {
+    cd ..
+    ~/.pyenv/versions/3.11.*/bin/python -m venv .venv
+    ls -la | grep .venv
+    return
+}
+test_activate_virtualenv() { 
+    PWD=`pwd`
+    . $PWD/.venv/bin/activate
+    return
+}
+
+test_pip() {
+    cd $NEW_PROJECT_NAME
+    pip install --upgrade pip wheel pip-tools
+    pip-compile
+    pip-sync
+    return
+}
+test_db() {
+    cd $NEW_PROJECT_NAME
+    if ! createdb $NEW_PROJECT_NAME; then
+    dropdb $NEW_PROJECT_NAME
+    createdb $NEW_PROJECT_NAME
+    fi
+}
+
+test_cp_local() {
+    cp $NEW_PROJECT_NAME/settings/local.py-template $NEW_PROJECT_NAME/settings/local.py
+    return
+}
+
+test_django_check() {
+    python manage.py check --fail-level WARNING
+    return
+}
+
+test_migrate() {
+    python manage.py migrate
+    return
+}
+
+if ! test_installation || ! test_create_virtualenv || ! test_activate_virtualenv || ! test_activate_virtualenv || ! test_pip || ! test_db  || ! test_cp_local || ! test_django_check || ! test_migrate; then
+    dropdb $NEW_PROJECT_NAME
+    cd $BASE_DIR
+    rm -rf .test_tmp/
+    return
+fi
+
+dropdb $NEW_PROJECT_NAME
+cd $BASE_DIR
+ls -la
+rm -rf .test_tmp/

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -13,7 +13,7 @@ cd test_project
 PROJECT_DIR=`pwd`
 
 export NEW_PROJECT_NAME=test_create_from_project_template
-export DJANGO_SETTINGS_MODULE=test_create_from_project_template.settings.base
+export DJANGO_SETTINGS_MODULE=test_create_from_project_template.settings.test
 export PGPASSWORD=postgres
 
 pip install django

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -10,6 +10,8 @@ cd .test_tmp
 mkdir test_project
 cd test_project
 
+PROJECT_DIR=`pwd`
+
 
 test_installation() {
     export NEW_PROJECT_NAME=test_create_from_project_template
@@ -19,7 +21,7 @@ test_installation() {
     return
 }
 test_create_virtualenv() {
-    cd ..
+    cd $PROJECT_DIR
     ~/.pyenv/versions/3.11.*/bin/python -m venv .venv
     ls -la | grep .venv
     return
@@ -69,5 +71,4 @@ fi
 
 dropdb $NEW_PROJECT_NAME
 cd $BASE_DIR
-ls -la
 rm -rf .test_tmp/

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -19,7 +19,7 @@ export PGPASSWORD=postgres
 pip install django
 
 test_installation() {
-    django-admin startproject --template=https://github.com/cruncher/project-template/zipball/2024/test-installation --extension=conf,py,sh,py-template,toml  $NEW_PROJECT_NAME
+    django-admin startproject --template=https://github.com/cruncher/project-template/zipball/master --extension=conf,py,sh,py-template,toml  $NEW_PROJECT_NAME
     cd $NEW_PROJECT_NAME
     sed -i s/{{project_name}}/$NEW_PROJECT_NAME/g $NEW_PROJECT_NAME/templates/base.html
     return

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -57,7 +57,7 @@ test_cp_local() {
 }
 
 test_django_check() {
-    python manage.py check --fail-level WARNING --settings=test_settings.py
+    python manage.py check --fail-level WARNING
     return
 }
 

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -12,9 +12,10 @@ cd test_project
 
 PROJECT_DIR=`pwd`
 
+export NEW_PROJECT_NAME=test_create_from_project_template
+export DJANGO_SETTINGS_MODULE=$NEW_PROJECT_NAME.settings.test
 
 test_installation() {
-    export NEW_PROJECT_NAME=test_create_from_project_template
     ~/.pyenv/versions/3.11.*/bin/django-admin startproject --template=https://github.com/cruncher/project-template/zipball/master --extension=conf,py,sh,py-template,toml  $NEW_PROJECT_NAME
     cd $NEW_PROJECT_NAME
     sed -i s/{{project_name}}/$NEW_PROJECT_NAME/g $NEW_PROJECT_NAME/templates/base.html
@@ -53,7 +54,7 @@ test_cp_local() {
 }
 
 test_django_check() {
-    python manage.py check --fail-level WARNING
+    python manage.py check --fail-level WARNING --settings=test_settings.py
     return
 }
 

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -13,6 +13,7 @@ cd test_project
 PROJECT_DIR=`pwd`
 
 export NEW_PROJECT_NAME=test_create_from_project_template
+export DJANGO_SETTINGS_MODULE=test_create_from_project_template.settings.base
 export PGPASSWORD=postgres
 
 pip install django
@@ -52,12 +53,13 @@ test_db() {
 
 test_cp_local() {
     cp $NEW_PROJECT_NAME/settings/local.py-template $NEW_PROJECT_NAME/settings/local.py
+    cat $NEW_PROJECT_NAME/settings/local.py
     return
 }
 
 test_django_check() {
-    pwd
-    python manage.py check --fail-level WARNING -v2
+    echo $DJANGO_SETTINGS_MODULE
+    python manage.py check --fail-level WARNING --settings=$DJANGO_SETTINGS_MODULE
     return
 }
 

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -13,7 +13,7 @@ cd test_project
 PROJECT_DIR=`pwd`
 
 export NEW_PROJECT_NAME=test_create_from_project_template
-export DJANGO_SETTINGS_MODULE=$NEW_PROJECT_NAME.settings.test
+export DJANGO_SETTINGS_MODULE=$NEW_PROJECT_NAME.$NEW_PROJECT_NAME.settings.test
 export PGPASSWORD=postgres
 
 pip install django

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -68,7 +68,7 @@ test_migrate() {
 }
 
 test_runserver() {
-    python manage.py runserver 0.0.0.0:8000 &!
+    python manage.py runserver 0.0.0.0:8000 &
     sleep 3
     return
 }

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -15,15 +15,17 @@ PROJECT_DIR=`pwd`
 export NEW_PROJECT_NAME=test_create_from_project_template
 export DJANGO_SETTINGS_MODULE=$NEW_PROJECT_NAME.settings.test
 
+pip install django
+
 test_installation() {
-    ~/.pyenv/versions/3.11.*/bin/django-admin startproject --template=https://github.com/cruncher/project-template/zipball/master --extension=conf,py,sh,py-template,toml  $NEW_PROJECT_NAME
+    django-admin startproject --template=https://github.com/cruncher/project-template/zipball/master --extension=conf,py,sh,py-template,toml  $NEW_PROJECT_NAME
     cd $NEW_PROJECT_NAME
     sed -i s/{{project_name}}/$NEW_PROJECT_NAME/g $NEW_PROJECT_NAME/templates/base.html
     return
 }
 test_create_virtualenv() {
     cd $PROJECT_DIR
-    ~/.pyenv/versions/3.11.*/bin/python -m venv .venv
+    python -m venv .venv
     ls -la | grep .venv
     return
 }

--- a/project_name/tests/test_installation.sh
+++ b/project_name/tests/test_installation.sh
@@ -56,7 +56,8 @@ test_cp_local() {
 }
 
 test_django_check() {
-    python manage.py check --fail-level WARNING
+    pwd
+    python manage.py check --fail-level WARNING -v2
     return
 }
 


### PR DESCRIPTION
A bash script for testing the installation steps.
Uses the steps defined in the readme.md
`source` keyword cannot be used in a script so it's replaced with "."
From the base directory:  `sh tests/test_installation.sh`
Creates a temporary test_tmp directory, 
Goes through installation steps, 
Added python manage.py check command as an extra step
If any of them fails, deletes the created directory.
If successful, deletes the created directory.